### PR TITLE
Add gemspec summary 

### DIFF
--- a/public_holidays.gemspec
+++ b/public_holidays.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.version       = PublicHolidays::VERSION
   spec.authors       = ["Adam Butler"]
   spec.email         = ["adam@littlebigmedia.co.uk"]
-  spec.summary       = %q{TODO: Write a short summary. Required.}
+  spec.summary       = %q{A gem that provides helper functionality for working with dates in which public holidays are a concern.}
   spec.description   = %q{TODO: Write a longer description. Optional.}
   spec.homepage      = ""
   spec.license       = "MIT"

--- a/public_holidays.gemspec
+++ b/public_holidays.gemspec
@@ -9,7 +9,6 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Adam Butler"]
   spec.email         = ["adam@littlebigmedia.co.uk"]
   spec.summary       = %q{A gem that provides helper functionality for working with dates in which public holidays are a concern.}
-  spec.description   = %q{TODO: Write a longer description. Optional.}
   spec.homepage      = ""
   spec.license       = "MIT"
 


### PR DESCRIPTION
Since summary is a gemspec requirement my server can't deploy when it's bundled with this gem

```
(Backtrace restricted to imported tasks)
cap aborted!
SSHKit::Runner::ExecuteError: Exception while executing as simpleweb@web02.foo.servers.jivatechnology.com: rake exit status: 1
rake stdout: Nothing written
rake stderr: /home/simpleweb/.rvm/gems/ruby-2.2.2/gems/bundler-1.10.3/lib/bundler.rb:374:in `rescue in load_gemspec_uncached': The gemspec at /var/www/foo/shared/bundle/ruby/2.2.0/bundler/gems/public_holidays-ffacca766621/public_holidays.gemspec is not valid. The validation error was '"FIXME" or "TODO" is not a description' (Bundler::InvalidOption)
    from /home/simpleweb/.rvm/gems/ruby-2.2.2/gems/bundler-1.10.3/lib/bundler.rb:360:in `load_gemspec_uncached'
    from /home/simpleweb/.rvm/gems/ruby-2.2.2/gems/bundler-1.10.3/lib/bundler.rb:353:in `load_gemspec'
    from /home/simpleweb/.rvm/gems/ruby-2.2.2/gems/bundler-1.10.3/lib/bundler/source/path.rb:134:in `block in load_spec_files'
    from /home/simpleweb/.rvm/gems/ruby-2.2.2/gems/bundler-1.10.3/lib/bundler/source/path.rb:133:in `each'
    from /home/simpleweb/.rvm/gems/ruby-2.2.2/gems/bundler-1.10.3/lib/bundler/source/path.rb:133:in `load_spec_files'
    from /home/simpleweb/.rvm/gems/ruby-2.2.2/gems/bundler-1.10.3/lib/bundler/source/git.rb:189:in `load_spec_files'
    from /home/simpleweb/.rvm/gems/ruby-2.2.2/gems/bundler-1.10.3/lib/bundler/source/path.rb:91:in `local_specs'
    from /home/simpleweb/.rvm/gems/ruby-2.2.2/gems/bundler-1.10.3/lib/bundler/source/git.rb:159:in `specs'
    from /home/simpleweb/.rvm/gems/ruby-2.2.2/gems/bundler-1.10.3/lib/bundler/lazy_specification.rb:53:in `__materialize__'
    from /home/simpleweb/.rvm/gems/ruby-2.2.2/gems/bundler-1.10.3/lib/bundler/spec_set.rb:88:in `block in materialize'
    from /home/simpleweb/.rvm/gems/ruby-2.2.2/gems/bundler-1.10.3/lib/bundler/spec_set.rb:85:in `map!'
    from /home/simpleweb/.rvm/gems/ruby-2.2.2/gems/bundler-1.10.3/lib/bundler/spec_set.rb:85:in `materialize'
    from /home/simpleweb/.rvm/gems/ruby-2.2.2/gems/bundler-1.10.3/lib/bundler/definition.rb:139:in `specs'
    from /home/simpleweb/.rvm/gems/ruby-2.2.2/gems/bundler-1.10.3/lib/bundler/definition.rb:184:in `specs_for'
    from /home/simpleweb/.rvm/gems/ruby-2.2.2/gems/bundler-1.10.3/lib/bundler/definition.rb:173:in `requested_specs'
    from /home/simpleweb/.rvm/gems/ruby-2.2.2/gems/bundler-1.10.3/lib/bundler/environment.rb:18:in `requested_specs'
    from /home/simpleweb/.rvm/gems/ruby-2.2.2/gems/bundler-1.10.3/lib/bundler/runtime.rb:13:in `setup'
    from /home/simpleweb/.rvm/gems/ruby-2.2.2/gems/bundler-1.10.3/lib/bundler.rb:127:in `setup'
    from /home/simpleweb/.rvm/gems/ruby-2.2.2/gems/bundler-1.10.3/lib/bundler/setup.rb:18:in `<top (required)>'
    from /home/simpleweb/.rvm/rubies/ruby-2.2.2/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
    from /home/simpleweb/.rvm/rubies/ruby-2.2.2/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
```
